### PR TITLE
Migrate Fabric8 Maven Plugin to Eclipse JKube OpenShift Maven Plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,18 @@
 https://appdev.openshift.io/docs/vertx-runtime.html#mission-rest-http-vertx
+
+## How to Build
+You can build this project with this maven command:
+```
+mvn clean install
+```
+
+## Deploying to [Red Hat OpenShift](https://www.openshift.com/)
+This project relies in [Eclipse JKube](https://github.com/eclipse/jkube)'s [OpenShift Maven Plugin](https://www.eclipse.org/jkube/docs/openshift-maven-plugin) for deploying to Red Hat OpenShift. OpenShift Maven Plugin is available in openshift profile. You can deploy this application using this command:
+```
+mvn oc:deploy -Popenshift
+```
+
+Once you're done with testing, you can undeploy this using this goal:
+```
+mvn oc:undeploy -Popenshift
+```

--- a/pom.xml
+++ b/pom.xml
@@ -15,14 +15,14 @@
     <vertx-maven-plugin.version>1.0.22</vertx-maven-plugin.version>
     <vertx.verticle>io.openshift.example.HttpApplication</vertx.verticle>
     
-    <fabric8-maven-plugin.version>4.4.1</fabric8-maven-plugin.version>
+    <jkube.version>1.0.2</jkube.version>
     <arquillian-cube.version>1.18.2</arquillian-cube.version>
 
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <fabric8.generator.from>registry.access.redhat.com/ubi8/openjdk-11</fabric8.generator.from>
+    <jkube.generator.from>registry.access.redhat.com/ubi8/openjdk-11</jkube.generator.from>
   </properties>
 
   <dependencyManagement>
@@ -147,12 +147,12 @@
       <build>
         <plugins>
           <plugin>
-            <groupId>io.fabric8</groupId>
-            <artifactId>fabric8-maven-plugin</artifactId>
-            <version>${fabric8-maven-plugin.version}</version>
+            <groupId>org.eclipse.jkube</groupId>
+            <artifactId>openshift-maven-plugin</artifactId>
+            <version>${jkube.version}</version>
             <executions>
               <execution>
-                <id>fmp</id>
+                <id>jkube</id>
                 <goals>
                   <goal>resource</goal>
                   <goal>build</goal>
@@ -164,12 +164,12 @@
             <configuration>
               <enricher>
                 <excludes>
-                  <exclude>f8-maven-scm</exclude>
+                  <exclude>jkube-maven-scm</exclude>
                 </excludes>
                 <config>
-                  <f8-healthcheck-vertx>
+                  <jkube-healthcheck-vertx>
                     <path>/health</path>
-                  </f8-healthcheck-vertx>
+                  </jkube-healthcheck-vertx>
                 </config>
               </enricher>
               <resources>


### PR DESCRIPTION
[Eclipse JKube](https://github.com/eclipse/jkube) is new rebranded and refactored version of [Fabric8 Maven Plugin](https://github.com/fabric8io/fabric8-maven-plugin). We are trying to increase awareness about project migration and gather feedback and support.

I've tested this on Red Hat OpenShift v3.11 and everything seems to be working as expected with OpenShift Maven Plugin.

Generated from Eclipse JKube [migrate goal](https://www.eclipse.org/jkube/docs/migration-guide/):
- For Red Hat OpenShift:
```
mvn org.eclipse.jkube:openshift-maven-plugin:migrate
```
- For Kubernetes:
```
mvn org.eclipse.jkube:kubernetes-maven-plugin:migrate
```